### PR TITLE
Start Hangout s0 ws

### DIFF
--- a/components/AcceptedHangouts.tsx
+++ b/components/AcceptedHangouts.tsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react'
+import React from 'react'
 import {
   Text,
   View,
@@ -11,7 +11,7 @@ import { connect } from 'react-redux'
 import { startHangout, finishHangout } from '../src/actions/hangouts'
 import Badges from './Badges'
 
-export const AcceptedHangouts = props => {
+const AcceptedHangouts = props => {
   return (
     <>
       <View style={{ flex: 1 }}>
@@ -41,7 +41,9 @@ export const AcceptedHangouts = props => {
                   <TouchableOpacity
                     style={styles.start_button}
                     onPress={() =>
-                      props.startHangout([props.currentUserLimited, hangout])
+                      props.socket.send(
+                        `s0 ${props.currentUserLimited.email} ${hangout.email} ${props.currentUserLimited.first_name}`
+                      )
                     }
                   >
                     <Text style={styles.button_text}>Start Hangout</Text>

--- a/src/actions/hangouts.ts
+++ b/src/actions/hangouts.ts
@@ -45,18 +45,12 @@ export const declineHangoutRequest = (currentUserEmail, fromUserEmail) => {
     dispatch({ type: 'DECLINE_REQUEST', fromUserEmail })
   }
 }
-export const startHangout = participants => {
-  return async dispatch => {
-    const hangoutId = await axios.post(`${apiUrl}/graphql`, {
-      query: print(startHangoutQuery),
-      variables: { participants }
-    })
-    dispatch({
-      type: 'START_HANGOUT',
-      participants,
-      hangoutId: hangoutId.data.data.StartHangout
-    })
-  }
+export const startHangout = async participants => {
+  const hangoutId = await axios.post(`${apiUrl}/graphql`, {
+    query: print(startHangoutQuery),
+    variables: { participants }
+  })
+  return hangoutId.data.data.StartHangout
 }
 
 export const finishHangout = (hangoutId, userToReview) => {

--- a/src/reducers/reducer.js
+++ b/src/reducers/reducer.js
@@ -81,7 +81,11 @@ const reducer = (state = initialState, action) => {
       return { ...state, showEditProfileForm: false }
     }
     case 'UPDATE_PROFILE': {
-      return { ...state, user: action.updatedUser, showEditProfileForm: false }
+      return {
+        ...state,
+        user: Object.assign(state.user, action.updatedUser),
+        showEditProfileForm: false
+      }
     }
     case 'SET_CHATS': {
       return { ...state, chats: action.chats }

--- a/views/Hangouts.tsx
+++ b/views/Hangouts.tsx
@@ -102,7 +102,9 @@ class Hangouts extends React.Component<Props> {
               {socket => <PendingHangouts socket={socket} />}
             </SocketContext.Consumer>
           ) : (
-            <AcceptedHangouts />
+            <SocketContext.Consumer>
+              {socket => <AcceptedHangouts socket={socket} />}
+            </SocketContext.Consumer>
           )}
           <View>
             <TouchableOpacity


### PR DESCRIPTION
-minor fix in UPDATE_PROFILE reducer. It was breaking because the user object was being overwritten by the updatedUser object, which didn't include all of the properties we needed. Now the updates will simply be applied to the existing user object without completely overwriting it.

-receive s0 ws code will alert user if other user claims they've started a hangout
     --> can ignore, OR...
     --> can confirm
            ----> query backend
            ----> dispatch action to reducer
            ----> send s1 ws code to let the other user know it's been confirmed (this logic isn't implemented yet)